### PR TITLE
Fix data type of location.latitude

### DIFF
--- a/chat-api/v2/openapi.yaml
+++ b/chat-api/v2/openapi.yaml
@@ -2672,7 +2672,7 @@ components:
           example:
             7.4954884
         latitude:
-          type: integer
+          type: number
           format: double
           description: Latitude part of the coordinate
           example:


### PR DESCRIPTION
Wrong data types causes issues with code generators based on the OpenAPI specification.