### PR TITLE
fixed typo in conversations inbox api base url

### DIFF
--- a/third-party/eazy/v1/openapi.yaml
+++ b/third-party/eazy/v1/openapi.yaml
@@ -83,7 +83,7 @@ info:
   x-repository: https://github.com/tyntec/api-collection/blob/master/third-party/eazy
   x-major-version: v1
 servers:
-  - url: https://api.cmd.tyntec.com/
+  - url: https://api.cmd.tyntec.com/v3/
 security:
   - bearerAuth: []
 tags:


### PR DESCRIPTION
This wrong base url was just pointed out to me by marcel.

Can you maybe merge and roll this out on monday?

Thx!!