### PR TITLE
Verify error codes and new descriptions

### DIFF
--- a/verify/v1/verify.yaml
+++ b/verify/v1/verify.yaml
@@ -14,25 +14,15 @@ info:
 servers:
   - url: https://api.tyntec.com/verify/v1
 tags:
-  - name: "Verify"
+  - name: "Verify with Criteria Templates"
     description: |
-      Verify service aims to provide information regarding the validity and trustworthyness 
-      of a phone number.
+      Verify service aims to provide information regarding phone numbers.
       
-      The service gathers and consolidates information regarding a phone number
-      and based on the collected information and customer's input is able to evaluate and suggest to the customer
-      if a phone number is verified.
+      Customers can define their own logic for verifying a number, by defining verify criteria templates. Customers can
+      also define the response parameters that they would like to receive back.
       
-      Furthermore the validation process can be fully pre-defined by the customer with the use of customized
-      verify criteria and customized responses. By using the customized criteria, customers can fully control
-      the verify process based on their business needs.
-  - name: "Verify Criteria"
-    description: |
-      Customers can define their own logic for verifying a number.
-      This means that customer can define the verify criteria but also the response parameters that 
-      they would like to  to receive back.
-      
-      This configuration provides customers with full control over tyntec's verify process.
+      This dynamic configuration, provides customers with full control over tyntec's verify service.
+
   - name: Metadata
     description: |
       Metadata provides non functional information about the Verify service
@@ -40,26 +30,47 @@ paths:
   /templates:
     post:
       tags:
-        - "Verify Criteria"
-      summary: Create criteria
+        - "Verify with Criteria Templates"
+      summary: Create criteria template
       description: |
-        Create criteria with desired verify rules and responses.
+        Create a Verify criteria template with desired verify rules and responses. Verify template creation is a crucial
+        step in the Verify process. Without this step Verify process cannot be done.
         
-        The following parameter can be configured:
+        There are two types of Verify criteria templates:
         
-        | Criterion           | Allowed Operations   | Allowed Values                                                                                                           |
-        | ---                 | ---                  | ---                                                                                                                    |
-        | activeNumber        | is                   | true/false                                                                                                               |
-        | numberType          | is, is_in            | fixed or mobile. In case of *is_in* operator multiple comma separated values can be provided                             |
-        | operatorCountry     | is, is_in            | country in ISO Alpha-3 format e.g. DEU, GBR. In case of *is_in* operator multiple comma separated values can be provided |
-        | disposableNumber    | is                   | true/false                                                                                                               |
-        | mccMnc              | is, is_in            | MCC and MNC of the operator e.g. 23202. In case of *is_in* operator multiple comma separated values can be provided      |
+         - Empty template or,
+         - Customized template
+        
+        **Empty Verify criteria template**
+        
+        Empty template means that the default verify and response parameters will be used. This practically means:
+        
+         - Verify criteria
+           - validNumberFormat: Verify that the phone number has a valid format
+           - numberType: Verify that the phone number type is fixed or mobile
 
-        From our side, we add "numberType" parameter by default if this parameter is not configured in a Template.
+         - Response parameters
+           - requestId: Unique request identifier
+           - verified: Verify outcome
+           - reason (only in case of unverified response)
+           - reasonCode (only in case of unverified response)
+
+        **Customized Verify criteria template**
+                
+        Customized templates are more complex to define but more powerful, since customers can define exactly how the
+        Verify service should verify phone numbers and how the response should look like.
         
+        The following verify parameter can be configured:
+        
+        | Criterion        | Allowed Operations | Allowed Values                                                                                                                  |
+        | ---              | ---                | ---                                                                                                                             |
+        | activeNumber     | is                 | true/false                                                                                                                      |
+        | numberType       | is, is_in          | fixed or mobile. <p>In case of *is_in* operator multiple comma separated values can be provided</p>                             |
+        | operatorCountry  | is, is_in          | country in ISO Alpha-3 format e.g. DEU, GBR. <p>In case of *is_in* operator multiple comma separated values can be provided</p> |
+        | disposableNumber | is                 | true/false                                                                                                                      |
+        | mccMnc           | is, is_in          | MCC and MNC of the operator e.g. 23202. <p>In case of *is_in* operator multiple comma separated values can be provided</p>      |
+
         The following parameters can be configured for the response:
-        
-        Response Parameter:
         
         - validNumberFormat
         - numberType
@@ -135,10 +146,10 @@ paths:
                 $ref: '#/components/schemas/error500'
     get:
       tags:
-        - "Verify Criteria"
-      summary: Retrieve all criteria
+        - "Verify with Criteria Templates"
+      summary: View all criteria templates
       description: |
-        Retrieve all verify criteria. Customers can list all criteria configured by them.
+        Retrieve all verify criteria templates created by the customer.
       security:
         - apiKey: [ ]
       responses:
@@ -181,16 +192,15 @@ paths:
   /templates/{name}:
     get:
       tags:
-        - "Verify Criteria"
-      summary: Retrieve criteria by name
+        - "Verify with Criteria Templates"
+      summary: View a criteria template
       description: |
-        Retrieve criteria by criteria name. Customers can view a specific criteria by knowing the criteria name.
+        Customers can view a specific criteria by knowing the criteria name.
       parameters:
-        - name: criteria-name
+        - name: criteriaTemplateName
           in: path
           required: true
-          description: |
-            The name of the criteria to be Name
+          description: Criteria template name
           schema:
             type: string
             example: "verify-criteria"
@@ -235,27 +245,49 @@ paths:
                 $ref: '#/components/schemas/error500'
     put:
       tags:
-        - "Verify Criteria"
-      summary: Update the criteria
+        - "Verify with Criteria Templates"
+      summary: Update criteria template
       description: |
-        Modify the existing criteria. Customers can update name, description, criteria and response by providing 
+        Modify an existing criteria template. Customers can update name, description, criteria and response by providing 
         the whole json structure.
         
-        Criteria can be configured similarly with the criteria create:
+        Criteria can be modified similarly with the criteria template creation.
         
-        | Criterion           | Allowed Operations   | Allowed Values                                                                                                           |
-        | ---                 | ---                  | ---                                                                                                                    |
-        | activeNumber        | is                   | true/false                                                                                                               |
-        | numberType          | is, is_in            | fixed or mobile. In case of *is_in* operator multiple comma separated values can be provided                             |
-        | operatorCountry     | is, is_in            | country in ISO Alpha-3 format e.g. DEU, GBR. In case of *is_in* operator multiple comma separated values can be provided |
-        | disposableNumber    | is                   | true/false                                                                                                               |
-        | mccMnc              | is, is_in            | MCC and MNC of the operator e.g. 23202. In case of *is_in* operator multiple comma separated values can be provided      |
+        There are two types of Verify criteria templates:
         
-        From our side, we add "numberType" parameter by default if this parameter is not configured in a Template.
+         - Empty template or,
+         - Customized template
         
-        And similarly response are also following the criteria create configuration:
+        **Empty Verify criteria template**
+        
+        Empty template means that the default verify and response parameters will be used. This practically means:
+        
+         - Verify criteria
+           - validNumberFormat: Verify that the phone number has a valid format
+           - numberType: Verify that the phone number type is fixed or mobile
 
-        Response Parameter:
+         - Response parameters
+           - requestId: Unique request identifier
+           - verified: Verify outcome
+           - reason (only in case of unverified response)
+           - reasonCode (only in case of unverified response)
+
+        **Customized Verify criteria template**
+        
+        Customized templates are more complex to define but more powerful, since customers can define exactly how the
+        Verify service should verify phone numbers and how the response should look like.
+        
+        The following verify parameter can be configured:
+        
+        | Criterion        | Allowed Operations | Allowed Values                                                                                                                  |
+        | ---              | ---                | ---                                                                                                                             |
+        | activeNumber     | is                 | true/false                                                                                                                      |
+        | numberType       | is, is_in          | fixed or mobile. <p>In case of *is_in* operator multiple comma separated values can be provided</p>                             |
+        | operatorCountry  | is, is_in          | country in ISO Alpha-3 format e.g. DEU, GBR. <p>In case of *is_in* operator multiple comma separated values can be provided</p> |
+        | disposableNumber | is                 | true/false                                                                                                                      |
+        | mccMnc           | is, is_in          | MCC and MNC of the operator e.g. 23202. <p>In case of *is_in* operator multiple comma separated values can be provided</p>      |
+
+        The following parameters can be configured for the response:
         
         - validNumberFormat
         - numberType
@@ -268,7 +300,7 @@ paths:
 
         In the Response message, parameters will respect the template configuration order.
         
-        Moreover, following parameters will be always shown in the response:
+        Moreover, following parameters will be always shown in the response
         
         - requestId
         - verified
@@ -278,13 +310,11 @@ paths:
         However, customers can use those parameters in the response configuration just for manipulating 
         the order of the Response parameters. 
 
-
       parameters:
-        - name: criteriaName
+        - name: criteriaTemplateName
           in: path
           required: true
-          description: |
-            provide the criteria Name
+          description: Criteria template name
           schema:
             type: string
             example: "verify-criteria"
@@ -341,16 +371,15 @@ paths:
                 $ref: '#/components/schemas/error500'
     delete:
       tags:
-        - "Verify Criteria"
-      summary: Delete criteria by name
+        - "Verify with Criteria Templates"
+      summary: Delete criteria template
       description: |
-        Delete criteria by criteria name.
+        Delete criteria template by using the criteria name.
       parameters:
-        - name: name
+        - name: criteriaTemplateName
           in: path
           required: true
-          description: |
-            provide the criteria Name
+          description: Criteria template name
           schema:
             type: string
             example: "verify-criteria"
@@ -393,55 +422,60 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error500'
-  /phone/{number}?criteria={criteriaName}:
+  /phone/{number}?criteria={criteriaTemplateName}:
     get:
       tags:
-        - "Verify Criteria"
-      summary: Verify criteria by name
+        - "Verify with Criteria Templates"
+      summary: Verify by criteria template
       description: |
-        Verify criteria by criteria name. Customers can view a specific response by setting up response parameter at the time of criteria creation.
+        Verify a phone number based on a criteria.
         
-        Unverified responses will always show the following four parameters:
+        Each criteria has a defined verify and response parameters, set at the criteria creation api request. 
+        Verify request is based on the defined criteria for providing feedback regarding the requested phone number. 
+        
+        Example of a successful Verify response is shown at the code section at the right side of this page.
+        
+        Unverified requests do not respect the defined parameter set in the response of the criteria, but they are using
+        a default set of response parameters, aiming to explain to the customer the reason that the request was unverified.
+        The unverified request response will always show the following four parameters:
+        
         - requestId
         - verified
         - reason
         - reasonCode
         
         Depending on the reason that the request is unverified, the following error codes and reasons will be sent back:
-                
-        |   reasonCode   |              reason                       |     Criterion       |
-        |      ---       |      ---                                  |       ---           |
-        |      1001      |  "validNumberFormat is false."            | ValidNumberFormat   |
-        |      1101      |  "activeNumber is false ."                | activeNumber        |
-        |      1102      |  "activeNumber is true."                  | activeNumber        |
-        |      1201      |  "numberType is fixed ."                  | numberType          |
-        |      1202      |  "numberType is mobile."                  | numberType          |
-        |      1203      |  "numberType is voip."                    | numberType          |
-        |      1204      |  "numberType is premium_rate."            | numberType          |
-        |      1205      |  "numberType is toll_free."               | numberType          |
-        |      1206      |  "numberType is shared_cost."             | numberType          |
-        |      1207      |  "numberType is unknown."                 | numberType          |
-        |      1208      |  "numberType is [rest unsupported type]." | numberType          |
-        |      1301      |  "operatorCountry is [country-name]."     | operatorCountry     |
-        |      1401      |  "mccMnc is [mccMnc-value]."              | mccMnc              |
-        |      2001      |  "disposableNumber is false."             | disposableNumber    |
-        |      2002      |  "disposableNumber is true."              | disposableNumber    |
+        
+        | reasonCode | Criterion         | reason                                                                                                        |
+        |    ---     | ---               | ---                                                                                                           |
+        |    1001    | ValidNumberFormat | The number format is incorrect, and it is not matching the defined verification criteria                      |
+        |    1101    | activeNumber      | The number is flagged as not active, indicating that it is not currently in use or accessible for communication, and it is not matching defined verification criteria | 
+        |    1102    | activeNumber      | The number is flagged as active, and it is not matching defined verification criteria                         |
+        |    1201    | numberType        | The number type is fixed, and it is not matching defined verification criteria                                |
+        |    1202    | numberType        | The number type is mobile, and it is not matching defined verification criteria                               |
+        |    1203    | numberType        | The number type is voip, and it is not matching defined verification criteria                                 |
+        |    1204    | numberType        | The number type is premium rate, and it is not matching defined verification criteria                         |
+        |    1205    | numberType        | The number type is toll free, and it is not matching defined verification criteria                            |
+        |    1206    | numberType        | The number type is shared cost, and it is not matching defined verification criteria                          |
+        |    1207    | numberType        | The number type is unknown, and it is not matching defined verification criteria                              |
+        |    1208    | numberType        | The number type is unsupported type, and it is not matching defined verification criteria                     |
+        |    1301    | operatorCountry   | Mobile number operator country is not matching defined verification criteria                                  |
+        |    1401    | mccMnc            | MCC – Mobile Country Code and MNC - Mobile Network Code are not matching defined verification criteria        |
+        |    2001    | disposableNumber  | The number is flagged as non-disposable, non-temporary, and it is not matching defined verification criteria  |
+        |    2002    | disposableNumber  | The number is flagged as disposable, temporary, and it is not matching defined verification criteria          |
 
-      
       parameters:
         - name: number
           in: path
           required: true
-          description: |
-            The phone number to be verified, given in the international format
+          description: The phone number to be verified, given in the international format
           schema:
             type: string
             example: +491621234567
-        - name: criteriaName
+        - name: criteriaTemplateName
           in: path
           required: true
-          description: |
-            The name of the criteria
+          description: Criteria template name
           schema:
             type: string
             example: "verify-criteria"

--- a/verify/v1/verify.yaml
+++ b/verify/v1/verify.yaml
@@ -54,6 +54,8 @@ paths:
         | operatorCountry     | is, is_in            | country in ISO Alpha-3 format e.g. DEU, GBR. In case of *is_in* operator multiple comma separated values can be provided |
         | disposableNumber    | is                   | true/false                                                                                                               |
         | mccMnc              | is, is_in            | MCC and MNC of the operator e.g. 23202. In case of *is_in* operator multiple comma separated values can be provided      |
+
+        From our side, we add "numberType" parameter by default if this parameter is not configured in a Template.
         
         The following parameters can be configured for the response:
         
@@ -75,6 +77,7 @@ paths:
         - requestId
         - verified
         - reason (only in case of unverified response)
+        - reasonCode (only in case of unverified response)
         
         However, customers can use those parameters in the response configuration just for manipulating 
         the order of the Response parameters. 
@@ -248,6 +251,8 @@ paths:
         | disposableNumber    | is                   | true/false                                                                                                               |
         | mccMnc              | is, is_in            | MCC and MNC of the operator e.g. 23202. In case of *is_in* operator multiple comma separated values can be provided      |
         
+        From our side, we add "numberType" parameter by default if this parameter is not configured in a Template.
+        
         And similarly response are also following the criteria create configuration:
 
         Response Parameter:
@@ -268,6 +273,7 @@ paths:
         - requestId
         - verified
         - reason (only in case of unverified response)
+        - reasonCode (only in case of unverified response)
         
         However, customers can use those parameters in the response configuration just for manipulating 
         the order of the Response parameters. 
@@ -394,6 +400,43 @@ paths:
       summary: Verify criteria by name
       description: |
         Verify criteria by criteria name. Customers can view a specific response by setting up response parameter at the time of criteria creation.
+        
+        Following Criterion can be cause of a unverified response:
+        - validNumberFormat (default parameter)
+        - numberType (default parameter if not specified)
+        - activeNumber
+        - operatorCountry
+        - mccMnc
+        - disposableNumber
+        
+        
+        Following 4 parameters will be always shown in case of unverified response:
+        - requestId
+        - verified
+        - reason
+        - reasonCode
+        
+        Example case of unverified response caused by following criterion: 
+        
+        |     Criterion       |   requestId  |  verified |              reason                       |   reasonCode   |      
+        |       ---           |     ---      |    ---    | 		 ---                                 |      ---       |       
+        | ValidNumberFormat   |   "8c194d"   |	false    |  "validNumberFormat is false."            |      1001      |     
+        | activeNumber        |   "8c294d"   |	false    |  "activeNumber is false ."       	     |      1101      |   
+        | activeNumber        |   "3c194d"   |	false    |  "activeNumber is true."         	     |      1102      |
+        | numberType          |   "4c194d"   |	false    |  "numberType is fixed ."         	     |      1201      | 
+        | numberType          |   "23c94d"   |	false    |  "numberType is mobile."         	     |      1202      |
+        | numberType          |   "1c194d"   |	false    |  "numberType is voip."           	     |      1203      |
+        | numberType          |   "frc194d"  |	false    |  "numberType is premium_rate."   	     |      1204      |
+        | numberType          |   "6c194d"   |	false    |  "numberType is toll_free."      	     |      1205      |
+        | numberType          |   "9gc194d"  |	false    |  "numberType is shared_cost."    	     |      1206      |
+        | numberType          |   "c4194d"   |	false    |  "numberType is unknown."       		     |      1207      |
+        | numberType          |   "u8c194d"  |	false    |  "numberType is [rest unsupported type]." |      1208      |
+        | operatorCountry     |   "hc194d"   |	false    |  "operatorCountry is [country-name]."     |      1301      |    
+        | mccMnc              |   "ewc194d"  |	false    |  "mccMnc is [mccMnc-value]."              |      1401  	  |
+        | disposableNumber    |   "w8c194d"  |	false    |  "disposableNumber is false."             |      2001      | 
+        | disposableNumber    |   "r8c194d"  |	false    |  "disposableNumber is true."              |      2002      |
+      
+
       parameters:
         - name: number
           in: path
@@ -419,7 +462,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VerifyResponse'
+                anyOf:
+                  - $ref: '#/components/schemas/VerifyResponse'
+                  - $ref: '#/components/schemas/ValidNumberFormatFalseResponse'
+                  - $ref: '#/components/schemas/ActiveNumberFalseResponse'
+                  - $ref: '#/components/schemas/ActiveNumberTrueResponse'
+                  - $ref: '#/components/schemas/NumberTypeFixedResponse'
+                  - $ref: '#/components/schemas/NumberTypeMobileResponse'
+                  - $ref: '#/components/schemas/NumberTypeVoipResponse'
+                  - $ref: '#/components/schemas/NumberTypePremiumRateResponse'
+                  - $ref: '#/components/schemas/NumberTypeTollFreeResponse'
+                  - $ref: '#/components/schemas/NumberTypeSharedCostResponse'
+                  - $ref: '#/components/schemas/NumberTypeUnknownResponse'
+                  - $ref: '#/components/schemas/RestUnsupportedNumberTypeResponse'
+                  - $ref: '#/components/schemas/OperatorCountryMismatchResponse'
+                  - $ref: '#/components/schemas/MccMncMismatchResponse'
+                  - $ref: '#/components/schemas/DisposableNumberFalseResponse'
+                  - $ref: '#/components/schemas/DisposableNumberTrueResponse'
         400:
           description: Bad request / Invalid request parameters
           content:
@@ -556,6 +615,291 @@ components:
           type: boolean
           example: true
           description: The final status of the number verify.
+    ValidNumberFormatFalseResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "validNumberFormat is false."
+          description: It is not a valid phone number.
+        reasonCode:
+          type: integer
+          example: 1001
+          description: reason code when validNumberFormat is false.
+    ActiveNumberFalseResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "activeNumber is false."
+          description: It is not an active phone number.
+        reasonCode:
+          type: integer
+          example: 1001
+          description: reason code when activeNumber = false but configured Template as activeNumber = true
+    ActiveNumberTrueResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "activeNumber is true."
+          description: This number is assigned to a subscriber.
+        reasonCode:
+          type: integer
+          example: 1102
+          description: reason code when activeNumber = true but configured Template Criterion is activeNumber = false.
+    NumberTypeFixedResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is fixed."
+          description: Type of the phone number (fixed)
+        reasonCode:
+          type: integer
+          example: 1201
+          description: reason code when numberType = "fixed" but configured Template Criterion is numberType = "mobile".
+    NumberTypeMobileResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is mobile."
+          description: Type of the phone number (mobile)
+        reasonCode:
+          type: integer
+          example: 1202
+          description: reason code when numberType = "mobile" but configured Template Criterion is numberType = "fixed".
+    NumberTypeVoipResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is voip."
+          description: Type of the phone number (voip)
+        reasonCode:
+          type: integer
+          example: 1203
+          description: reason code when given phone number type is "voip", which is a unsupported number type.
+    NumberTypePremiumRateResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is premium_rate."
+          description: Type of the phone number (premium_rate)
+        reasonCode:
+          type: integer
+          example: 1204
+          description: reason code when given phone number type is "premium_rate", which is a unsupported number type.
+    NumberTypeTollFreeResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is toll_free."
+          description: Type of the phone number (toll_free)
+        reasonCode:
+          type: integer
+          example: 1205
+          description: reason code when given phone number type is "toll_free", which is a unsupported number type.
+    NumberTypeSharedCostResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is shared_cost."
+          description: Type of the phone number (shared_cost)
+        reasonCode:
+          type: integer
+          example: 1206
+          description: reason code when given phone number type is "shared_cost", which is a unsupported number type.
+    NumberTypeUnknownResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is unknown."
+          description: Type of the phone number (unknown)
+        reasonCode:
+          type: integer
+          example: 1207
+          description: reason code when given phone number type is "unknown", which is a unsupported number type.
+    RestUnsupportedNumberTypeResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "numberType is [value]."
+          description: Type of the phone number (rest unsupported number type)
+        reasonCode:
+          type: integer
+          example: 1208
+          description: reason code for rest unsupported number type.
+    OperatorCountryMismatchResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "operatorCountry is [provided-number-country-name]."
+          description: The phone number's country of origin ISO3 code.
+        reasonCode:
+          type: integer
+          example: 1301
+          description: reason code when number operatorCountry and configured Template criterion operatorCountry is a mismatch. For example, number operatorCountry = "DEU" but configured Template criterion operatorCountry = "USA".
+    MccMncMismatchResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "mccMnc is [provided-number-mccMnc-value]."
+          description: MCC and MNC for given phone number
+        reasonCode:
+          type: integer
+          example: 1401
+          description: reason code when MCC and MNC for given phone number and configured Template criterion mccMnc is a mismatch. For example, number mccMnc = "26207" but configured Template criterion mccMnc = "21207".
+    DisposableNumberFalseResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "disposableNumber is false."
+          description: number is not disposable.
+        reasonCode:
+          type: integer
+          example: 2001
+          description: reason code when disposableNumber = false but configured Template Criterion is disposableNumber = true
+    DisposableNumberTrueResponse:
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: "4457068c-194d-4f72-9550-13b81ec054a9"
+          description: Unique ID of the request.
+        verified:
+          type: boolean
+          example: false
+          description: The final status of the number verify.
+        reason:
+          type: String
+          example: "disposableNumber is true."
+          description: number is disposable.
+        reasonCode:
+          type: integer
+          example: 2002
+          description: reason code when disposableNumber = true but configured Template Criterion is disposableNumber = false
     CreateCriteria:
       type: object
       properties:
@@ -802,14 +1146,14 @@ components:
           type: string
           example: "Not Found"
           description: Error of bad request
-        message:
-          type: string
-          example: "Request path '/...' does not exist"
-          description: Not Found
         status:
           type: integer
           example: 404
           description: HTTP error code
+        message:
+          type: string
+          example: "Requested path '/...' could not be found"
+          description: Not Found
     error409:
       type: object
       properties:

--- a/verify/v1/verify.yaml
+++ b/verify/v1/verify.yaml
@@ -401,42 +401,33 @@ paths:
       description: |
         Verify criteria by criteria name. Customers can view a specific response by setting up response parameter at the time of criteria creation.
         
-        Following Criterion can be cause of a unverified response:
-        - validNumberFormat (default parameter)
-        - numberType (default parameter if not specified)
-        - activeNumber
-        - operatorCountry
-        - mccMnc
-        - disposableNumber
-        
-        
-        Following 4 parameters will be always shown in case of unverified response:
+        Unverified responses will always show the following four parameters:
         - requestId
         - verified
         - reason
         - reasonCode
         
-        Example case of unverified response caused by following criterion: 
-        
-        |     Criterion       |   requestId  |  verified |              reason                       |   reasonCode   |      
-        |       ---           |     ---      |    ---    | 		 ---                                 |      ---       |       
-        | ValidNumberFormat   |   "8c194d"   |	false    |  "validNumberFormat is false."            |      1001      |     
-        | activeNumber        |   "8c294d"   |	false    |  "activeNumber is false ."       	     |      1101      |   
-        | activeNumber        |   "3c194d"   |	false    |  "activeNumber is true."         	     |      1102      |
-        | numberType          |   "4c194d"   |	false    |  "numberType is fixed ."         	     |      1201      | 
-        | numberType          |   "23c94d"   |	false    |  "numberType is mobile."         	     |      1202      |
-        | numberType          |   "1c194d"   |	false    |  "numberType is voip."           	     |      1203      |
-        | numberType          |   "frc194d"  |	false    |  "numberType is premium_rate."   	     |      1204      |
-        | numberType          |   "6c194d"   |	false    |  "numberType is toll_free."      	     |      1205      |
-        | numberType          |   "9gc194d"  |	false    |  "numberType is shared_cost."    	     |      1206      |
-        | numberType          |   "c4194d"   |	false    |  "numberType is unknown."       		     |      1207      |
-        | numberType          |   "u8c194d"  |	false    |  "numberType is [rest unsupported type]." |      1208      |
-        | operatorCountry     |   "hc194d"   |	false    |  "operatorCountry is [country-name]."     |      1301      |    
-        | mccMnc              |   "ewc194d"  |	false    |  "mccMnc is [mccMnc-value]."              |      1401  	  |
-        | disposableNumber    |   "w8c194d"  |	false    |  "disposableNumber is false."             |      2001      | 
-        | disposableNumber    |   "r8c194d"  |	false    |  "disposableNumber is true."              |      2002      |
-      
+        Depending on the reason that the request is unverified, the following error codes and reasons will be sent back:
+                
+        |   reasonCode   |              reason                       |     Criterion       |
+        |      ---       |      ---                                  |       ---           |
+        |      1001      |  "validNumberFormat is false."            | ValidNumberFormat   |
+        |      1101      |  "activeNumber is false ."                | activeNumber        |
+        |      1102      |  "activeNumber is true."                  | activeNumber        |
+        |      1201      |  "numberType is fixed ."                  | numberType          |
+        |      1202      |  "numberType is mobile."                  | numberType          |
+        |      1203      |  "numberType is voip."                    | numberType          |
+        |      1204      |  "numberType is premium_rate."            | numberType          |
+        |      1205      |  "numberType is toll_free."               | numberType          |
+        |      1206      |  "numberType is shared_cost."             | numberType          |
+        |      1207      |  "numberType is unknown."                 | numberType          |
+        |      1208      |  "numberType is [rest unsupported type]." | numberType          |
+        |      1301      |  "operatorCountry is [country-name]."     | operatorCountry     |
+        |      1401      |  "mccMnc is [mccMnc-value]."              | mccMnc              |
+        |      2001      |  "disposableNumber is false."             | disposableNumber    |
+        |      2002      |  "disposableNumber is true."              | disposableNumber    |
 
+      
       parameters:
         - name: number
           in: path


### PR DESCRIPTION
Following changes applied to the Verify product
 - Error codes added to the verify product for explaining why a request is unverified
 - Re-writing most of the Verify product descriptions for explaining in more detail how to configure and use the Verify product