### PR TITLE
WhatsApp bsuid in calls & other changes

### DIFF
--- a/conversations/v3/README.md
+++ b/conversations/v3/README.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## 3.29
+### Changes
+#### Added new WhatsApp bsuid identifiers to inbound call message webhook events
+The `whatsapp` property in inbound call message webhook events now includes new identifiers related to the username feature of whatsapp. The new fields are:
+* `bsuid` - the WhatsApp Business Scoped User ID of the end-user.
+* `parentBsuid` - the parent BSUID if enabled by the business
+* `username` - the WhatsApp username of the end-user, if feature is enabled by the end-user
+
+#### Added new WhatsApp contact request
+Added support for a new WhatsApp contact request interactive message, which allows businesses to receive contact information from end users who initiate contact through WhatsApp. This can also be added as a button to WhatsApp templates.
+
 ## 3.28
 ### Changes
 #### Added new whatsapp bsuid identifiers to inbound message and status webhook events

--- a/conversations/v3/webhook-events-v2.yaml
+++ b/conversations/v3/webhook-events-v2.yaml
@@ -1186,10 +1186,10 @@ components:
             - whatsapp
         from:
           type: string
-          description: The caller phone number of the call, including the country code
+          description: The caller of the call. This is the phone number (with the country code) if available, or the caller bsuid
         to:
           type: string
-          description: The receiver phone number of the call, including the country code
+          description: The receiver of the call. This is the phone number (with the country code) if available, or the receiver bsuid
         timestamp:
           type: string
           format: 'date-time'
@@ -1236,6 +1236,22 @@ components:
         duration:
           type: number
           description: The duration of the call in seconds
+        whatsapp:
+          type: object
+          description: Details specific to the WhatsApp channel
+          properties:
+            senderName:
+              type: string
+              description: The name of the end user, set in their profile
+            bsuid:
+              type: string
+              description: The WhatsApp Business scoped user ID (BSUID) of the end user.
+            parentBsuid:
+              type: string
+              description: If enabled for your business, this is the parent bsuid of the end user.
+            username:
+              type: string
+              description: The WhatsApp username of the end user, if set.
       example:
         event: Call::Connect
         channel: whatsapp
@@ -1248,6 +1264,11 @@ components:
         session:
           type: answer
           sdp: <<RFC 8866 SDP>>
+        whatsapp:
+          senderName: Peter
+          bsuid: DE.1234567890
+          parentBsuid: DE.0987654321
+          username: "@peter.123"
     WhatsAppCallRingingStatus:
       type: object
       description: Indicates the call is ringing

--- a/conversations/v3/whatsapp.yaml
+++ b/conversations/v3/whatsapp.yaml
@@ -2167,6 +2167,7 @@ components:
             - $ref: '#/components/schemas/WhatsAppInteractiveProductListMessage'
             - $ref: '#/components/schemas/WhatsAppInteractiveLocationMessage'
             - $ref: '#/components/schemas/WhatsAppInteractiveCallPermissionRequestMessage'
+            - $ref: '#/components/schemas/WhatsAppInteractiveContactRequestMessage'
             - $ref: '#/components/schemas/WhatsAppInteractiveFlowMessage'
             - $ref: '#/components/schemas/WhatsAppInteractiveAddressMessage'
             - $ref: '#/components/schemas/WhatsAppInteractiveUrlButtonMessage'
@@ -3137,6 +3138,21 @@ components:
           body:
             type: text
             text: We would like to call you.
+    WhatsAppInteractiveContactRequestMessage:
+      type: object
+      description: |
+        Interactive Contact Request Message
+      required:
+        - subType
+        - components
+      properties:
+        subType:
+          type: string
+          description: Determines the type of interactive message. **Always** `contactRequest`
+          enum:
+            - contactRequest
+        components:
+          $ref: '#/components/schemas/WhatsAppInteractiveContactRequestComponents'
     WhatsAppInteractiveFlowMessage:
       type: object
       description: |
@@ -3513,6 +3529,15 @@ components:
       type: object
       description: |
         A call permission request component. It contains only body text. A footer with a link to the Business calling permission setting is automatically generated.
+      required:
+        - body
+      properties:
+        body:
+          $ref: '#/components/schemas/WhatsAppInteractiveTextContent'
+    WhatsAppInteractiveContactRequestComponents:
+      type: object
+      description: |
+        A contact request component. It contains only body text. Create a contact request where users can share their contact information with the business.
       required:
         - body
       properties:
@@ -4557,6 +4582,7 @@ components:
           - $ref: '#/components/schemas/WhatsAppURLButton'
           - $ref: '#/components/schemas/WhatsAppPhoneNumberButton'
           - $ref: '#/components/schemas/WhatsAppVoiceCallButton'
+          - $ref: '#/components/schemas/WhatsAppRequestContactInfoButton'
       minItems: 1
       maxItems: 2
     WhatsAppURLButton:
@@ -4627,30 +4653,42 @@ components:
           pattern: ^\+\d{4,23}$
           example: "+4923147790813"
     WhatsAppVoiceCallButton:
-        type: object
-        description: A call to action button that initiates a voice call to that particular WhatsApp Business Account.
-        required:
-          - type
-          - text
-        properties:
-            type:
-              type: string
-              description: The type of this button
-              enum:
-                - VOICE_CALL
-              example: VOICE_CALL
-            text:
-              type: string
-              description: The caption for this button
-              maxLength: 20
-              minLength: 1
-              example: Call us
-            timeToLiveMinutes:
-              type: integer
-              description: The time to live for the voice call button. If the button is not clicked within this time frame, it will disappear from the message. Must be between 1440 and 43200 minutes. Default is 1440 minutes (24 hours).
-              minimum: 1440
-              maximum: 43200
-              example: 1440
+      type: object
+      description: A call to action button that initiates a voice call to that particular WhatsApp Business Account.
+      required:
+        - type
+        - text
+      properties:
+        type:
+          type: string
+          description: The type of this button
+          enum:
+            - VOICE_CALL
+          example: VOICE_CALL
+        text:
+          type: string
+          description: The caption for this button
+          maxLength: 20
+          minLength: 1
+          example: Call us
+        timeToLiveMinutes:
+          type: integer
+          description: The time to live for the voice call button. If the button is not clicked within this time frame, it will disappear from the message. Must be between 1440 and 43200 minutes. Default is 1440 minutes (24 hours).
+          minimum: 1440
+          maximum: 43200
+          example: 1440
+    WhatsAppRequestContactInfoButton:
+      type: object
+      description: A call to action button that requests contact information from the end user.
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          description: The type of this button
+          enum:
+          - REQUEST_CONTACT_INFO
+          example: REQUEST_CONTACT_INFO
     WhatsAppFlowButtonsRequest:
       type: array
       description: Flows buttons


### PR DESCRIPTION
#### Added new WhatsApp bsuid identifiers to inbound call message webhook events
The `whatsapp` property in inbound call message webhook events now includes new identifiers related to the username feature of whatsapp. The new fields are:
* `bsuid` - the WhatsApp Business Scoped User ID of the end-user.
* `parentBsuid` - the parent BSUID if enabled by the business
* `username` - the WhatsApp username of the end-user, if feature is enabled by the end-user

#### Added new WhatsApp contact request
Added support for a new WhatsApp contact request interactive message, which allows businesses to receive contact information from end users who initiate contact through WhatsApp. This can also be added as a button to WhatsApp templates.
